### PR TITLE
use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: GitHub CI
+on: ["push", "pull_request"]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest --cov=.
+    - name: Upload coverage data
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
+        COVERALLS_PARALLEL: true
+        COVERALLS_SERVICE_NAME: github
+  coveralls:
+    name: Indicate completion
+    needs: test
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Finished
+        run: |
+          pip3 install --upgrade coveralls
+          coveralls  --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 AATools
+Copyright (c) 2019-2021 AATools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # IBM IB metrics exporter
 
-[![Build Status](https://travis-ci.com/AATools/ib-metrics-pyclient.svg?branch=master)](https://travis-ci.com/AATools/ib-metrics-pyclient) [![Coverage Status](https://coveralls.io/repos/github/AATools/ib-metrics-pyclient/badge.svg?branch=master)](https://coveralls.io/github/AATools/ib-metrics-pyclient?branch=master)
+[![Actions Status](https://github.com/AATools/ib-metrics-pyclient/workflows/GitHub%20CI/badge.svg)](https://github.com/AATools/ib-metrics-pyclient/actions) [![Coverage Status](https://coveralls.io/repos/github/AATools/ib-metrics-pyclient/badge.svg?branch=master)](https://coveralls.io/github/AATools/ib-metrics-pyclient?branch=master)
 
 This is python client for collecting IBM Integration Bus metrics and exporting to [Prometheus pushgateway](https://github.com/prometheus/pushgateway).
 The collected metrics can be explored in Prometheus or Grafana.
 
 The metrics are collected using [mqsilist](https://www.ibm.com/support/knowledgecenter/en/SSMKHH_9.0.0/com.ibm.etools.mft.doc/an07250_.htm) command. So, you need to install `IBM Integration Bus`.
 
-Tested for IBM IB v9 and v10 and Python 2.7, 3.6 on Linux.
+Tested for IBM IB v9 and v10 and Python 3.6, 3.7 on Linux.
 
 ## Collected metrics
 


### PR DESCRIPTION
- Switched to using GitHub Actions instead Travis CI for run tests. File `.travis.yml`  remained in the repository for memory.
- Removed Python 2.7 from docs.
- Updated LICENSE.

Bye-Bye Travis CI...