### PR TITLE
Сustom time interval between collecting metrics

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    if __name__ == .__main__.:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The metrics provided by the client:
 * `ib_application_status...` - current status of IB application;
 * `ib_message_flow_status...` -  current status of IB message flow.
 
-
 See [detailed description of the metrics](#metrics-detailed-description) for an in-depth understanding.
 
 You can run `IB metrics pyclient` and [MQ metrics pyclient](https://github.com/AATools/mq-metrics-pyclient) together. Metrics from both clients will be sent to the same pushgateway. Conflicts will not arise.
@@ -48,12 +47,12 @@ nohup python3 iib_metrics_client.py &
 
 After that, you should set up your Prometheus server to collect metrics from Pushgateway (`http://<hostname>:9091/metrics`).
 
-You can specify `host` and `port` for pushgateway and Integration Bus version via command-line arguments.
+You can specify `host` and `port` for pushgateway, Integration Bus version and time interval in seconds between collecting metrics via command-line arguments.
 
 ```bash
 python3 iib_metrics_client.py -h
 
-usage: iib_metrics_client.py [-h] [--pghost [pushgatewayHost]] [--pgport [pushgatewayPort]] [--iibver [iibVersion]]
+usage: iib_metrics_client.py [-h] [--pghost [pushgatewayHost]] [--pgport [pushgatewayPort]] [--iibver [iibVersion]] [--collectint [collectInterval]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -63,6 +62,8 @@ optional arguments:
                         pushgateway port
   --iibver [iibVersion]
                         IIB version: 9 or 10
+  --collectint [collectInterval]
+                        time interval between collecting metrics
 ```
 
 If argument is not set the default value is used.
@@ -72,6 +73,7 @@ If argument is not set the default value is used.
 | `pghost` | Pushgateway host | Hostname on which client is started.<br> Value define via `platform.node()`. |
 | `pgport` | Pushgateway port | `9091` |
 | `iibver` | IIB version | `9`<br> Valid value: **9** or **10**.<br> If argument is omitted or invalid value is passed, the client will try to determine version via environment variable `MQSI_VERSION_V`. If it can't determine the version using the environment variable, the default value will be used. |
+| `collectint` | Time interval between collecting metrics | `60` <br> Time in seconds. |
 
 ## Grafana dashboard
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is python client for collecting IBM Integration Bus metrics and exporting to [Prometheus pushgateway](https://github.com/prometheus/pushgateway).
 The collected metrics can be explored in Prometheus or Grafana.
 
-The metrics are collected using [mqsilist](https://www.ibm.com/support/knowledgecenter/en/SSMKHH_9.0.0/com.ibm.etools.mft.doc/an07250_.htm) command. So, you need to install `IBM Integration Bus`.
+The metrics are collected by using [mqsilist](https://www.ibm.com/support/knowledgecenter/en/SSMKHH_9.0.0/com.ibm.etools.mft.doc/an07250_.htm) command. The metrics are collected for **all local** Brokers. You need to run `IB metrics pyclient` in the same host where `IBM Integration Bus` was installed.
 
 Tested for IBM IB v9 and v10 and Python 3.6, 3.7 on Linux.
 

--- a/iib_metrics_client.py
+++ b/iib_metrics_client.py
@@ -32,7 +32,7 @@ class PrometheusBadResponse(Exception):
 def static_content():
     """Client name and version."""
     name = "ib-metrics-pyclient"
-    version = "0.3"
+    version = "0.4"
     return '{0} v.{1}'.format(name, version)
 
 
@@ -53,7 +53,7 @@ def parse_commandline_args():
     parser.add_argument('--pghost', metavar='pushgatewayHost', nargs='?', default=platform.node(), dest='pushgateway_host', help='pushgateway host')
     parser.add_argument('--pgport', metavar='pushgatewayPort', nargs='?', default='9091', dest='pushgateway_port', help='pushgateway port')
     parser.add_argument('--iibver', metavar='iibVersion', nargs='?', default=None, dest='iib_cmd_ver', help='IIB version: 9 or 10')
-    parser.add_argument('--collectint', metavar='collectInterval', nargs='?', default=60, type=int, dest='sleep_interval', help='time interval between collecting metrics ')
+    parser.add_argument('--collectint', metavar='collectInterval', nargs='?', default=60, type=int, dest='sleep_interval', help='time interval between collecting metrics')
     args = parser.parse_args()
     if (args.iib_cmd_ver is None) or ((args.iib_cmd_ver != '9') and (args.iib_cmd_ver != '10')):
         logger.info("Trying to determine Integration Bus version from environment variable MQSI_VERSION_V.")

--- a/iib_metrics_client.py
+++ b/iib_metrics_client.py
@@ -53,13 +53,14 @@ def parse_commandline_args():
     parser.add_argument('--pghost', metavar='pushgatewayHost', nargs='?', default=platform.node(), dest='pushgateway_host', help='pushgateway host')
     parser.add_argument('--pgport', metavar='pushgatewayPort', nargs='?', default='9091', dest='pushgateway_port', help='pushgateway port')
     parser.add_argument('--iibver', metavar='iibVersion', nargs='?', default=None, dest='iib_cmd_ver', help='IIB version: 9 or 10')
+    parser.add_argument('--collectint', metavar='collectInterval', nargs='?', default=60, type=int, dest='sleep_interval', help='time interval between collecting metrics ')
     args = parser.parse_args()
     if (args.iib_cmd_ver is None) or ((args.iib_cmd_ver != '9') and (args.iib_cmd_ver != '10')):
         logger.info("Trying to determine Integration Bus version from environment variable MQSI_VERSION_V.")
         iib_cmd_ver = get_version_from_env()
     else:
         iib_cmd_ver = args.iib_cmd_ver
-    return args.pushgateway_host, args.pushgateway_port, iib_cmd_ver
+    return args.pushgateway_host, args.pushgateway_port, iib_cmd_ver, abs(args.sleep_interval)
 
 
 def put_metric_to_gateway(metric_data, job, pushgateway_host, pushgateway_port):
@@ -138,8 +139,9 @@ def get_iib_metrics(pushgateway_host, pushgateway_port, mqsilist_command, bip_co
 
 if __name__ == "__main__":
     logger.info("Run {0}".format(static_content()))
-    pushgateway_host, pushgateway_port, iib_ver = parse_commandline_args()
+    pushgateway_host, pushgateway_port, iib_ver, sleep_interval = parse_commandline_args()
     logger.info("Integration Bus version: {0}".format(iib_ver))
+    logger.info("Metrics will be collected every {0} seconds".format(sleep_interval))
     mqsilist_command, bip_codes_brokers, bip_codes_components = get_platform_params_for_commands(iib_ver=iib_ver)
     while True:
         get_iib_metrics(
@@ -148,4 +150,4 @@ if __name__ == "__main__":
             mqsilist_command=mqsilist_command,
             bip_codes_brokers=bip_codes_brokers,
             bip_codes_components=bip_codes_components)
-        time.sleep(60)
+        time.sleep(sleep_interval)

--- a/tests/test_iib_metrics_client.py
+++ b/tests/test_iib_metrics_client.py
@@ -159,6 +159,7 @@ class TestParseCommandlineArgs(unittest.TestCase):
     pushgateway_host = 'testhost'
     pushgateway_port = '9091'
     iib_ver = '9'
+    sleep_interval=60
 
     Mocked = MockFunction()
     @patch('iib_metrics_client.logger.info', side_effect=Mocked.mock_logging_info)
@@ -167,12 +168,13 @@ class TestParseCommandlineArgs(unittest.TestCase):
         return_value=argparse.Namespace(
             pushgateway_host= pushgateway_host,
             pushgateway_port= pushgateway_port,
-            iib_cmd_ver= iib_ver))
+            iib_cmd_ver= iib_ver,
+            sleep_interval= sleep_interval))
     def test_parse_commandline_args(self, mock_logging_info, mock_args):
         """Test for `parse_commandline_args` function."""
         self.assertEqual(
             parse_commandline_args(), 
-            (self.pushgateway_host, self.pushgateway_port, self.iib_ver))
+            (self.pushgateway_host, self.pushgateway_port, self.iib_ver, self.sleep_interval))
 
     @patch('iib_metrics_client.logger.info', side_effect=Mocked.mock_logging_info)
     @patch(
@@ -180,12 +182,13 @@ class TestParseCommandlineArgs(unittest.TestCase):
         return_value=argparse.Namespace(
             pushgateway_host= pushgateway_host,
             pushgateway_port= pushgateway_port,
-            iib_cmd_ver=None))
+            iib_cmd_ver= None,
+            sleep_interval= sleep_interval))
     def test_parse_commandline_args_is_none(self, mock_logging_info, mock_args):
         """Test for `parse_commandline_args` function for `iib_cmd_ver` is None."""
         self.assertEqual(
             parse_commandline_args(),
-            (self.pushgateway_host, self.pushgateway_port, self.iib_ver))
+            (self.pushgateway_host, self.pushgateway_port, self.iib_ver, self.sleep_interval))
 
     @patch('iib_metrics_client.logger.info', side_effect=Mocked.mock_logging_info)
     @patch(
@@ -193,12 +196,27 @@ class TestParseCommandlineArgs(unittest.TestCase):
         return_value=argparse.Namespace(
             pushgateway_host= pushgateway_host,
             pushgateway_port= pushgateway_port,
-            iib_cmd_ver='42'))
+            iib_cmd_ver= '42',
+            sleep_interval= sleep_interval))
     def test_parse_commandline_args_is_42(self, mock_logging_info, mock_args):
         """Test for `parse_commandline_args` function for `iib_cmd_ver` is not valid."""
         self.assertEqual(
             parse_commandline_args(),
-            (self.pushgateway_host, self.pushgateway_port, self.iib_ver))
+            (self.pushgateway_host, self.pushgateway_port, self.iib_ver, self.sleep_interval))
+
+    @patch('iib_metrics_client.logger.info', side_effect=Mocked.mock_logging_info)
+    @patch(
+        'argparse.ArgumentParser.parse_args', 
+        return_value=argparse.Namespace(
+            pushgateway_host= pushgateway_host,
+            pushgateway_port= pushgateway_port,
+            iib_cmd_ver= iib_ver,
+            sleep_interval= -60))
+    def test_parse_commandline_args_is_negative_60(self, mock_logging_info, mock_args):
+        """Test for `parse_commandline_args` function for `sleep_interval` is `-60`."""
+        self.assertEqual(
+            parse_commandline_args(),
+            (self.pushgateway_host, self.pushgateway_port, self.iib_ver, self.sleep_interval))
 
 
 


### PR DESCRIPTION
* Added the ability to set a custom time interval between collecting metrics. Startup option `--collectint`.
* Added `.coveragerc`